### PR TITLE
doc(contributing): remove release branches

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,8 +15,7 @@ The supporting branches are:
 
 - **feat**: These branches are created from the develop branch and merged back into it when the feature is completed. They are used to implement new features or enhancements for the project. They are named as ``feature/<feature-name>``, where ``<feature-name>`` is a short and descriptive name of the feature.
 - **fix**: These branches are created from the develop branch and merged back into it when the fix is completed. They are used to fix bugs or issues in the project. They are named as ``fix/<issue-number>``, where ``<issue-number>`` is the issue number of the bug tracker.
-- **hotfix**: These branches are created from the main branch and merged back into it and the develop branch when the hotfix is completed. They are used to fix urgent bugs or issues in the released versions of the project. They are named as ``hotfix/<version>-<issue-number>``, where ``<version>`` is the version number of the release and `<issue-number>` is the issue number of the bug tracker.
-- **release**: These branches are created from the develop branch and merged back into it and the main branch when the release is ready. They are used to prepare and test the new versions of the project before releasing them. They are named as ``release/<version>``, where ``<version>`` is the version number of the release.
+- **hotfix**: These branches are created from the main branch and merged back into it and the develop branch when the hotfix is completed. They are used to fix urgent bugs or issues in the released versions of the project. They are named as ``hotfix/<issue-number>``, where `<issue-number>` is the issue number of the bug tracker.
 
 Git Convention
 --------------


### PR DESCRIPTION
## Description

Updated contributibg guide to remove release branches. The project team believes it is not necessary to have them.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
