### PR TITLE
fix(handle-download): create temp filename from filename

### DIFF
--- a/hydrogram/client.py
+++ b/hydrogram/client.py
@@ -853,7 +853,8 @@ class Client(Methods):
         ) = packet
 
         None if in_memory else Path(directory).mkdir(parents=True, exist_ok=True)
-        temp_file_path = Path(directory).resolve() / file_name + ".temp"
+        file_path = Path(directory).resolve() / file_name
+        temp_file_path = file_path.with_suffix(".temp")
         with BytesIO() if in_memory else Path(temp_file_path).open("wb") as file:
             try:
                 async for chunk in self.get_file(
@@ -877,7 +878,6 @@ class Client(Methods):
                     file.name = file_name
                     return file
                 file.close()
-                file_path = Path(temp_file_path).suffix
                 shutil.move(temp_file_path, file_path)
                 return file_path
 


### PR DESCRIPTION
## Description

Currently, the filename was being created from the suffix of the temp filename, thus leading to the file always be called `.temp`. This fixes it and also does the reverse: It now creates the temp filename from the actual filename, which feels better to me.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
