### PR TITLE
fix: fix a boolean instead of file name & prevent from closing BytesIO object

### DIFF
--- a/hydrogram/methods/messages/send_audio.py
+++ b/hydrogram/methods/messages/send_audio.py
@@ -189,7 +189,7 @@ class SendAudio:
                                 duration=duration, performer=performer, title=title
                             ),
                             raw.types.DocumentAttributeFilename(
-                                file_name=file_name or Path(audio).is_file()
+                                file_name=file_name or Path(audio).name
                             ),
                         ],
                     )


### PR DESCRIPTION
## Description

This PR fixes two issues, one caused by a typo where a `Path(audio).is_file()` (bool) was passed to `file_name` in send_audio.py. The other was caused by closing the BytesIO object prematurely, making the returned BytesIO object unreadable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
