### PR TITLE
fix: defer loop obtaining to when it's actually used

### DIFF
--- a/hydrogram/client.py
+++ b/hydrogram/client.py
@@ -330,7 +330,6 @@ class Client(Methods):
         self.updates_watchdog_event = asyncio.Event()
         self.last_update_time = datetime.now()
 
-        self.loop = asyncio.get_event_loop()
         self.listeners = {listener_type: [] for listener_type in ListenerTypes}
 
     async def __aenter__(self):
@@ -339,6 +338,10 @@ class Client(Methods):
     async def __aexit__(self, *args):
         with contextlib.suppress(ConnectionError):
             await self.stop()
+
+    @functools.cached_property
+    def loop(self):
+        return asyncio.get_running_loop()
 
     async def updates_watchdog(self):
         while True:

--- a/hydrogram/client.py
+++ b/hydrogram/client.py
@@ -341,7 +341,12 @@ class Client(Methods):
 
     @functools.cached_property
     def loop(self):
-        return asyncio.get_running_loop()
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            _loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(_loop)
+            return _loop
 
     async def updates_watchdog(self):
         while True:

--- a/hydrogram/connection/transport/tcp/tcp.py
+++ b/hydrogram/connection/transport/tcp/tcp.py
@@ -55,7 +55,7 @@ class TCP:
         self.writer: asyncio.StreamWriter | None = None
 
         self.lock = asyncio.Lock()
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.get_running_loop()
 
     async def _connect_via_proxy(self, destination: tuple[str, int]) -> None:
         scheme = self.proxy.get("scheme")

--- a/hydrogram/methods/messages/download_media.py
+++ b/hydrogram/methods/messages/download_media.py
@@ -19,7 +19,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import os
 from datetime import datetime
 from pathlib import Path
@@ -196,5 +195,5 @@ class DownloadMedia:
 
         if block:
             return await downloader
-        asyncio.get_event_loop().create_task(downloader)
+        self.loop.create_task(downloader)
         return None

--- a/hydrogram/methods/pyromod/listen.py
+++ b/hydrogram/methods/pyromod/listen.py
@@ -84,8 +84,7 @@ class Listen:
             inline_message_id=inline_message_id,
         )
 
-        loop = asyncio.get_event_loop()
-        future = loop.create_future()
+        future = self.loop.create_future()
 
         listener = Listener(
             future=future,

--- a/hydrogram/methods/utilities/idle.py
+++ b/hydrogram/methods/utilities/idle.py
@@ -70,7 +70,7 @@ async def idle():
 
     def signal_handler(signum, __):
         logging.info("Stop signal received (%s). Exiting...", signals[signum])
-        asyncio.get_event_loop().run_in_executor(None, task.cancel)
+        asyncio.get_running_loop().run_in_executor(None, task.cancel)
 
     for s in (SIGINT, SIGTERM, SIGABRT):
         signal_fn(s, signal_handler)

--- a/hydrogram/methods/utilities/run.py
+++ b/hydrogram/methods/utilities/run.py
@@ -17,7 +17,6 @@
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
 
-import asyncio
 from typing import TYPE_CHECKING
 
 from hydrogram.methods.utilities.idle import idle
@@ -70,13 +69,12 @@ class Run:
 
                 app.run(main())
         """
-        loop = asyncio.get_event_loop()
-        run = loop.run_until_complete
+        run = self.loop.run_until_complete
 
         if coroutine is not None:
             run(coroutine)
         else:
-            if loop.is_running():
+            if self.loop.is_running():
                 raise RuntimeError(
                     "You must call client.run() method outside of an asyncio event loop. "
                     "Otherwise, you can use client.start(), client.idle(), and client.stop() "

--- a/hydrogram/utils.py
+++ b/hydrogram/utils.py
@@ -47,7 +47,7 @@ async def ainput(prompt: str = "", *, hide: bool = False):
     """Just like the built-in input, but async"""
     with ThreadPoolExecutor(1) as executor:
         func = functools.partial(getpass if hide else input, prompt)
-        return await asyncio.get_event_loop().run_in_executor(executor, func)
+        return await asyncio.get_running_loop().run_in_executor(executor, func)
 
 
 def get_input_media_from_file_id(

--- a/news/49.misc.rst
+++ b/news/49.misc.rst
@@ -1,0 +1,1 @@
+Defer loop obtaining to when it's actually used.


### PR DESCRIPTION
## Description

This change makes Client.loop a cached property, so it's lazily evaluated after `__init__` when we're in an actual async context.
It enables users to define their Client() instances outside an async function when using .start(), .idle() and .stop() functions separately.

This change also removes the loop requirement from `add_handler` and `remove_handler`, which made no sense as it was creating an async function without any awaits inside (except for `asyncio.Lock()`, which is something that happens by simply not making it an async function at all).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
