### PR TITLE
Fix get_chat_history locking issue with takeout session

### DIFF
--- a/hydrogram/methods/messages/get_chat_history.py
+++ b/hydrogram/methods/messages/get_chat_history.py
@@ -38,19 +38,21 @@ async def get_chunk(
     from_message_id: int = 0,
     from_date: datetime = utils.zero_datetime(),
 ):
-    messages = await client.invoke(
-        raw.functions.messages.GetHistory(
-            peer=await client.resolve_peer(chat_id),
-            offset_id=from_message_id,
-            offset_date=utils.datetime_to_timestamp(from_date),
-            add_offset=offset,
-            limit=limit,
-            max_id=0,
-            min_id=0,
-            hash=0,
-        ),
-        sleep_threshold=60,
+    query = raw.functions.messages.GetHistory(
+        peer=await client.resolve_peer(chat_id),
+        offset_id=from_message_id,
+        offset_date=utils.datetime_to_timestamp(from_date),
+        add_offset=offset,
+        limit=limit,
+        max_id=0,
+        min_id=0,
+        hash=0,
     )
+
+    if client.takeout:
+        query = raw.functions.InvokeWithTakeout(takeout_id=client.takeout_id, query=query)
+
+    messages = await client.invoke(query, sleep_threshold=60)
 
     return await utils.parse_messages(client, messages, replies=0)
 


### PR DESCRIPTION
Fixes #48

Fix `get_chat_history` locking issue with takeout sessions.

* Add a check for `self.takeout` in the `get_chat_history` method.
* Adjust the query to use `InvokeWithTakeout` when `self.takeout` is `True`.

