### PR TITLE
feat: add some missing attributes

### DIFF
--- a/hydrogram/methods/messages/copy_message.py
+++ b/hydrogram/methods/messages/copy_message.py
@@ -42,6 +42,7 @@ class CopyMessage:
         message_thread_id: int | None = None,
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         disable_notification: bool | None = None,
         reply_to_message_id: int | None = None,
         schedule_date: datetime | None = None,
@@ -84,6 +85,9 @@ class CopyMessage:
             caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
                 List of special entities that appear in the new caption, which can be specified instead of *parse_mode*.
 
+            show_caption_above_media (``bool``, *optional*):
+                Pass True if the caption should be shown above the media.
+
             disable_notification (``bool``, *optional*):
                 Sends the message silently.
                 Users will receive a notification with no sound.
@@ -122,6 +126,7 @@ class CopyMessage:
             caption=caption,
             parse_mode=parse_mode,
             caption_entities=caption_entities,
+            show_caption_above_media=show_caption_above_media,
             disable_notification=disable_notification,
             message_thread_id=message_thread_id,
             reply_to_message_id=reply_to_message_id,

--- a/hydrogram/methods/messages/send_animation.py
+++ b/hydrogram/methods/messages/send_animation.py
@@ -43,6 +43,7 @@ class SendAnimation:
         unsave: bool = False,
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         has_spoiler: bool | None = None,
         duration: int = 0,
         width: int = 0,
@@ -94,6 +95,9 @@ class SendAnimation:
 
             caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
                 List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
+
+            show_caption_above_media (``bool``, *optional*):
+                Pass True if the caption should be shown above the animation.
 
             has_spoiler (``bool``, *optional*):
                 Pass True if the animation needs to be covered with a spoiler animation.
@@ -249,6 +253,7 @@ class SendAnimation:
                             random_id=self.rnd_id(),
                             schedule_date=utils.datetime_to_timestamp(schedule_date),
                             noforwards=protect_content,
+                            invert_media=show_caption_above_media,
                             reply_markup=await reply_markup.write(self) if reply_markup else None,
                             **await utils.parse_text_entities(
                                 self, caption, parse_mode, caption_entities

--- a/hydrogram/methods/messages/send_audio.py
+++ b/hydrogram/methods/messages/send_audio.py
@@ -42,6 +42,7 @@ class SendAudio:
         message_thread_id: int | None = None,
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         duration: int = 0,
         performer: str | None = None,
         title: str | None = None,
@@ -90,6 +91,9 @@ class SendAudio:
 
             caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
                 List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
+
+            show_caption_above_media (``bool``, *optional*):
+                Pass True if the caption should be shown above the audio.
 
             duration (``int``, *optional*):
                 Duration of the audio in seconds.
@@ -229,6 +233,7 @@ class SendAudio:
                             random_id=self.rnd_id(),
                             schedule_date=utils.datetime_to_timestamp(schedule_date),
                             noforwards=protect_content,
+                            invert_media=show_caption_above_media,
                             reply_markup=await reply_markup.write(self) if reply_markup else None,
                             **await utils.parse_text_entities(
                                 self, caption, parse_mode, caption_entities

--- a/hydrogram/methods/messages/send_cached_media.py
+++ b/hydrogram/methods/messages/send_cached_media.py
@@ -38,6 +38,7 @@ class SendCachedMedia:
         message_thread_id: int | None = None,
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         disable_notification: bool | None = None,
         reply_to_message_id: int | None = None,
         schedule_date: datetime | None = None,
@@ -79,6 +80,9 @@ class SendCachedMedia:
             caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
                 List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+            show_caption_above_media (``bool``, *optional*):
+                Pass True if the caption should be shown above the media.
+
             disable_notification (``bool``, *optional*):
                 Sends the message silently.
                 Users will receive a notification with no sound.
@@ -116,6 +120,7 @@ class SendCachedMedia:
                 random_id=self.rnd_id(),
                 schedule_date=utils.datetime_to_timestamp(schedule_date),
                 noforwards=protect_content,
+                invert_media=show_caption_above_media,
                 reply_markup=await reply_markup.write(self) if reply_markup else None,
                 **await utils.parse_text_entities(self, caption, parse_mode, caption_entities),
             )

--- a/hydrogram/methods/messages/send_location.py
+++ b/hydrogram/methods/messages/send_location.py
@@ -36,6 +36,7 @@ class SendLocation:
         longitude: float,
         *,
         message_thread_id: int | None = None,
+        horizontal_accuracy: int | None = None,
         disable_notification: bool | None = None,
         reply_to_message_id: int | None = None,
         schedule_date: datetime | None = None,
@@ -64,6 +65,9 @@ class SendLocation:
             message_thread_id (``int``, *optional*):
                 Unique identifier for the target message thread (topic) of the forum.
                 for forum supergroups only.
+
+            horizontal_accuracy (``int``, *optional*):
+                The estimated horizontal accuracy of the location, in meters.
 
             disable_notification (``bool``, *optional*):
                 Sends the message silently.
@@ -97,7 +101,9 @@ class SendLocation:
             raw.functions.messages.SendMedia(
                 peer=await self.resolve_peer(chat_id),
                 media=raw.types.InputMediaGeoPoint(
-                    geo_point=raw.types.InputGeoPoint(lat=latitude, long=longitude)
+                    geo_point=raw.types.InputGeoPoint(
+                        lat=latitude, long=longitude, accuracy_radius=horizontal_accuracy
+                    )
                 ),
                 message="",
                 silent=disable_notification or None,

--- a/hydrogram/methods/messages/send_photo.py
+++ b/hydrogram/methods/messages/send_photo.py
@@ -42,6 +42,7 @@ class SendPhoto:
         message_thread_id: int | None = None,
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         has_spoiler: bool | None = None,
         ttl_seconds: int | None = None,
         disable_notification: bool | None = None,
@@ -85,6 +86,9 @@ class SendPhoto:
 
             caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
                 List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
+
+            show_caption_above_media (``bool``, *optional*):
+                Pass True if the caption should be shown above the photo.
 
             has_spoiler (``bool``, *optional*):
                 Pass True if the photo needs to be covered with a spoiler animation.
@@ -188,6 +192,7 @@ class SendPhoto:
                             random_id=self.rnd_id(),
                             schedule_date=utils.datetime_to_timestamp(schedule_date),
                             noforwards=protect_content,
+                            invert_media=show_caption_above_media,
                             reply_markup=await reply_markup.write(self) if reply_markup else None,
                             **await utils.parse_text_entities(
                                 self, caption, parse_mode, caption_entities

--- a/hydrogram/methods/messages/send_video.py
+++ b/hydrogram/methods/messages/send_video.py
@@ -42,6 +42,7 @@ class SendVideo:
         message_thread_id: int | None = None,
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         has_spoiler: bool | None = None,
         no_sound: bool | None = None,
         ttl_seconds: int | None = None,
@@ -92,6 +93,9 @@ class SendVideo:
 
             caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
                 List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
+
+            show_caption_above_media (``bool``, *optional*):
+                Pass True if the caption should be shown above the video.
 
             has_spoiler (``bool``, *optional*):
                 Pass True if the video needs to be covered with a spoiler animation.
@@ -261,6 +265,7 @@ class SendVideo:
                             random_id=self.rnd_id(),
                             schedule_date=utils.datetime_to_timestamp(schedule_date),
                             noforwards=protect_content,
+                            invert_media=show_caption_above_media,
                             reply_markup=await reply_markup.write(self) if reply_markup else None,
                             **await utils.parse_text_entities(
                                 self, caption, parse_mode, caption_entities

--- a/hydrogram/types/inline_mode/inline_query_result_animation.py
+++ b/hydrogram/types/inline_mode/inline_query_result_animation.py
@@ -71,6 +71,9 @@ class InlineQueryResultAnimation(InlineQueryResult):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (``bool``, *optional*):
+            Wether the caption should be shown above the animation.
+
         reply_markup (:obj:`~hydrogram.types.InlineKeyboardMarkup`, *optional*):
             An InlineKeyboardMarkup object.
 
@@ -92,6 +95,7 @@ class InlineQueryResultAnimation(InlineQueryResult):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         reply_markup: types.InlineKeyboardMarkup = None,
         input_message_content: types.InputMessageContent = None,
     ):
@@ -108,6 +112,7 @@ class InlineQueryResultAnimation(InlineQueryResult):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
@@ -156,6 +161,7 @@ class InlineQueryResultAnimation(InlineQueryResult):
                     else None,
                     message=message,
                     entities=entities,
+                    invert_media=self.show_caption_above_media,
                 )
             ),
         )

--- a/hydrogram/types/inline_mode/inline_query_result_audio.py
+++ b/hydrogram/types/inline_mode/inline_query_result_audio.py
@@ -59,6 +59,9 @@ class InlineQueryResultAudio(InlineQueryResult):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (:obj:`bool`, *optional*):
+            Wether the caption should be shown above the audio.
+
         reply_markup (:obj:`~hydrogram.types.InlineKeyboardMarkup`, *optional*):
             Inline keyboard attached to the message.
 
@@ -76,6 +79,7 @@ class InlineQueryResultAudio(InlineQueryResult):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         reply_markup: types.InlineKeyboardMarkup = None,
         input_message_content: types.InputMessageContent = None,
     ):
@@ -88,6 +92,7 @@ class InlineQueryResultAudio(InlineQueryResult):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
 
     async def write(self, client: hydrogram.Client):
         audio = raw.types.InputWebDocument(
@@ -123,6 +128,7 @@ class InlineQueryResultAudio(InlineQueryResult):
                     else None,
                     message=message,
                     entities=entities,
+                    invert_media=self.show_caption_above_media,
                 )
             ),
         )

--- a/hydrogram/types/inline_mode/inline_query_result_cached_animation.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_animation.py
@@ -54,6 +54,9 @@ class InlineQueryResultCachedAnimation(InlineQueryResult):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (``bool``, *optional*):
+            Wether the caption should be shown above the animation.
+
         reply_markup (:obj:`~hydrogram.types.InlineKeyboardMarkup`, *optional*):
             An InlineKeyboardMarkup object.
 
@@ -69,6 +72,7 @@ class InlineQueryResultCachedAnimation(InlineQueryResult):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         reply_markup: types.InlineKeyboardMarkup = None,
         input_message_content: types.InputMessageContent = None,
     ):
@@ -79,6 +83,7 @@ class InlineQueryResultCachedAnimation(InlineQueryResult):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
@@ -109,6 +114,7 @@ class InlineQueryResultCachedAnimation(InlineQueryResult):
                     else None,
                     message=message,
                     entities=entities,
+                    invert_media=self.show_caption_above_media,
                 )
             ),
         )

--- a/hydrogram/types/inline_mode/inline_query_result_cached_audio.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_audio.py
@@ -50,6 +50,9 @@ class InlineQueryResultCachedAudio(InlineQueryResult):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (:obj:`bool`, *optional*):
+            Wether the caption should be shown above the audio.
+
         reply_markup (:obj:`~hydrogram.types.InlineKeyboardMarkup`, *optional*):
             An InlineKeyboardMarkup object.
 
@@ -64,6 +67,7 @@ class InlineQueryResultCachedAudio(InlineQueryResult):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         reply_markup: types.InlineKeyboardMarkup = None,
         input_message_content: types.InputMessageContent = None,
     ):
@@ -73,6 +77,7 @@ class InlineQueryResultCachedAudio(InlineQueryResult):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
@@ -102,6 +107,7 @@ class InlineQueryResultCachedAudio(InlineQueryResult):
                     else None,
                     message=message,
                     entities=entities,
+                    invert_media=self.show_caption_above_media,
                 )
             ),
         )

--- a/hydrogram/types/inline_mode/inline_query_result_cached_document.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_document.py
@@ -56,6 +56,9 @@ class InlineQueryResultCachedDocument(InlineQueryResult):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (:obj:`bool`, *optional*):
+            Wether the caption should be shown above the document.
+
         reply_markup (:obj:`~hydrogram.types.InlineKeyboardMarkup`, *optional*):
             An InlineKeyboardMarkup object.
 
@@ -72,6 +75,7 @@ class InlineQueryResultCachedDocument(InlineQueryResult):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         reply_markup: types.InlineKeyboardMarkup = None,
         input_message_content: types.InputMessageContent = None,
     ):
@@ -83,6 +87,7 @@ class InlineQueryResultCachedDocument(InlineQueryResult):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
@@ -114,6 +119,7 @@ class InlineQueryResultCachedDocument(InlineQueryResult):
                     else None,
                     message=message,
                     entities=entities,
+                    invert_media=self.show_caption_above_media,
                 )
             ),
         )

--- a/hydrogram/types/inline_mode/inline_query_result_cached_photo.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_photo.py
@@ -56,6 +56,9 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (:obj:`bool`, *optional*):
+            Wether the caption should be shown above the photo.
+
         reply_markup (:obj:`~hydrogram.types.InlineKeyboardMarkup`, *optional*):
             An InlineKeyboardMarkup object.
 
@@ -72,6 +75,7 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         reply_markup: types.InlineKeyboardMarkup = None,
         input_message_content: types.InputMessageContent = None,
     ):
@@ -83,6 +87,7 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
@@ -112,6 +117,7 @@ class InlineQueryResultCachedPhoto(InlineQueryResult):
                     else None,
                     message=message,
                     entities=entities,
+                    invert_media=self.show_caption_above_media,
                 )
             ),
         )

--- a/hydrogram/types/inline_mode/inline_query_result_cached_video.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_video.py
@@ -57,6 +57,9 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (:obj:`bool`, *optional*):
+            Wether the caption should be shown above the video.
+
         reply_markup (:obj:`~hydrogram.types.InlineKeyboardMarkup`, *optional*):
             An InlineKeyboardMarkup object.
 
@@ -73,6 +76,7 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         reply_markup: types.InlineKeyboardMarkup = None,
         input_message_content: types.InputMessageContent = None,
     ):
@@ -84,6 +88,7 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
@@ -115,6 +120,7 @@ class InlineQueryResultCachedVideo(InlineQueryResult):
                     else None,
                     message=message,
                     entities=entities,
+                    invert_media=self.show_caption_above_media,
                 )
             ),
         )

--- a/hydrogram/types/inline_mode/inline_query_result_cached_voice.py
+++ b/hydrogram/types/inline_mode/inline_query_result_cached_voice.py
@@ -54,6 +54,9 @@ class InlineQueryResultCachedVoice(InlineQueryResult):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (:obj:`bool`, *optional*):
+            Wether the caption should be shown above the voice message.
+
         reply_markup (:obj:`~hydrogram.types.InlineKeyboardMarkup`, *optional*):
             An InlineKeyboardMarkup object.
 
@@ -69,6 +72,7 @@ class InlineQueryResultCachedVoice(InlineQueryResult):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         reply_markup: types.InlineKeyboardMarkup = None,
         input_message_content: types.InputMessageContent = None,
     ):
@@ -79,6 +83,7 @@ class InlineQueryResultCachedVoice(InlineQueryResult):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
@@ -109,6 +114,7 @@ class InlineQueryResultCachedVoice(InlineQueryResult):
                     else None,
                     message=message,
                     entities=entities,
+                    invert_media=self.show_caption_above_media,
                 )
             ),
         )

--- a/hydrogram/types/inline_mode/inline_query_result_document.py
+++ b/hydrogram/types/inline_mode/inline_query_result_document.py
@@ -56,6 +56,9 @@ class InlineQueryResultDocument(InlineQueryResult):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (:obj:`bool`, *optional*):
+            Wether the caption should be shown above the document.
+
         description (``str``, *optional*):
             Short description of the result.
 
@@ -84,6 +87,7 @@ class InlineQueryResultDocument(InlineQueryResult):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         description: str = "",
         reply_markup: types.InlineKeyboardMarkup = None,
         input_message_content: types.InputMessageContent = None,
@@ -99,6 +103,7 @@ class InlineQueryResultDocument(InlineQueryResult):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
         self.description = description
         self.thumb_url = thumb_url
         self.thumb_width = thumb_width
@@ -144,6 +149,7 @@ class InlineQueryResultDocument(InlineQueryResult):
                     else None,
                     message=message,
                     entities=entities,
+                    invert_media=self.show_caption_above_media,
                 )
             ),
         )

--- a/hydrogram/types/inline_mode/inline_query_result_photo.py
+++ b/hydrogram/types/inline_mode/inline_query_result_photo.py
@@ -67,6 +67,9 @@ class InlineQueryResultPhoto(InlineQueryResult):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (:obj:`bool`, *optional*):
+            Wether the caption should be shown above the photo.
+
         reply_markup (:obj:`~hydrogram.types.InlineKeyboardMarkup`, *optional*):
             An InlineKeyboardMarkup object.
 
@@ -86,6 +89,7 @@ class InlineQueryResultPhoto(InlineQueryResult):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         reply_markup: types.InlineKeyboardMarkup = None,
         input_message_content: types.InputMessageContent = None,
     ):
@@ -100,6 +104,7 @@ class InlineQueryResultPhoto(InlineQueryResult):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
         self.reply_markup = reply_markup
         self.input_message_content = input_message_content
 
@@ -142,6 +147,7 @@ class InlineQueryResultPhoto(InlineQueryResult):
                     else None,
                     message=message,
                     entities=entities,
+                    invert_media=self.show_caption_above_media,
                 )
             ),
         )

--- a/hydrogram/types/inline_mode/inline_query_result_video.py
+++ b/hydrogram/types/inline_mode/inline_query_result_video.py
@@ -72,6 +72,9 @@ class InlineQueryResultVideo(InlineQueryResult):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (:obj:`bool`, *optional*):
+            Wether the caption should be shown above the video.
+
         reply_markup (:obj:`~hydrogram.types.InlineKeyboardMarkup`, *optional*):
             Inline keyboard attached to the message
 
@@ -94,6 +97,7 @@ class InlineQueryResultVideo(InlineQueryResult):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         reply_markup: types.InlineKeyboardMarkup = None,
         input_message_content: types.InputMessageContent = None,
     ):
@@ -109,6 +113,7 @@ class InlineQueryResultVideo(InlineQueryResult):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
         self.mime_type = mime_type
 
     async def write(self, client: hydrogram.Client):
@@ -151,6 +156,7 @@ class InlineQueryResultVideo(InlineQueryResult):
                     else None,
                     message=message,
                     entities=entities,
+                    invert_media=self.show_caption_above_media,
                 )
             ),
         )

--- a/hydrogram/types/inline_mode/inline_query_result_voice.py
+++ b/hydrogram/types/inline_mode/inline_query_result_voice.py
@@ -56,6 +56,9 @@ class InlineQueryResultVoice(InlineQueryResult):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (:obj:`bool`, *optional*):
+            Wether the caption should be shown above the voice message.
+
         reply_markup (:obj:`~hydrogram.types.InlineKeyboardMarkup`, *optional*):
             Inline keyboard attached to the message.
 
@@ -72,6 +75,7 @@ class InlineQueryResultVoice(InlineQueryResult):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         reply_markup: types.InlineKeyboardMarkup = None,
         input_message_content: types.InputMessageContent = None,
     ):
@@ -83,6 +87,7 @@ class InlineQueryResultVoice(InlineQueryResult):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
 
     async def write(self, client: hydrogram.Client):
         audio = raw.types.InputWebDocument(
@@ -117,6 +122,7 @@ class InlineQueryResultVoice(InlineQueryResult):
                     else None,
                     message=message,
                     entities=entities,
+                    invert_media=self.show_caption_above_media,
                 )
             ),
         )

--- a/hydrogram/types/input_media/input_media.py
+++ b/hydrogram/types/input_media/input_media.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, BinaryIO
 from hydrogram.types.object import Object
 
 if TYPE_CHECKING:
+    from hydrogram import enums
     from hydrogram.types.messages_and_media import MessageEntity
 
 
@@ -43,8 +44,9 @@ class InputMedia(Object):
         self,
         media: str | BinaryIO,
         caption: str = "",
-        parse_mode: str | None = None,
+        parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
     ):
         super().__init__()
 
@@ -52,3 +54,4 @@ class InputMedia(Object):
         self.caption = caption
         self.parse_mode = parse_mode
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media

--- a/hydrogram/types/input_media/input_media_animation.py
+++ b/hydrogram/types/input_media/input_media_animation.py
@@ -56,6 +56,9 @@ class InputMediaAnimation(InputMedia):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (``bool``, *optional*):
+            Wether the caption should be shown above the animation.
+
         width (``int``, *optional*):
             Animation width.
 
@@ -76,12 +79,13 @@ class InputMediaAnimation(InputMedia):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         width: int = 0,
         height: int = 0,
         duration: int = 0,
         has_spoiler: bool | None = None,
     ):
-        super().__init__(media, caption, parse_mode, caption_entities)
+        super().__init__(media, caption, parse_mode, caption_entities, show_caption_above_media)
 
         self.thumb = thumb
         self.width = width

--- a/hydrogram/types/input_media/input_media_audio.py
+++ b/hydrogram/types/input_media/input_media_audio.py
@@ -58,6 +58,9 @@ class InputMediaAudio(InputMedia):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (``bool``, *optional*):
+            Wether the caption should be shown above the audio.
+
         duration (``int``, *optional*):
             Duration of the audio in seconds
 
@@ -75,11 +78,12 @@ class InputMediaAudio(InputMedia):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         duration: int = 0,
         performer: str = "",
         title: str = "",
     ):
-        super().__init__(media, caption, parse_mode, caption_entities)
+        super().__init__(media, caption, parse_mode, caption_entities, show_caption_above_media)
 
         self.thumb = thumb
         self.duration = duration

--- a/hydrogram/types/input_media/input_media_document.py
+++ b/hydrogram/types/input_media/input_media_document.py
@@ -55,6 +55,9 @@ class InputMediaDocument(InputMedia):
 
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
+
+        show_caption_above_media (``bool``, *optional*):
+            Wether the caption should be shown above the document.
     """
 
     def __init__(
@@ -64,7 +67,8 @@ class InputMediaDocument(InputMedia):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
     ):
-        super().__init__(media, caption, parse_mode, caption_entities)
+        super().__init__(media, caption, parse_mode, caption_entities, show_caption_above_media)
 
         self.thumb = thumb

--- a/hydrogram/types/input_media/input_media_photo.py
+++ b/hydrogram/types/input_media/input_media_photo.py
@@ -51,6 +51,9 @@ class InputMediaPhoto(InputMedia):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (``bool``, *optional*):
+            Wether the caption should be shown above the photo.
+
         has_spoiler (``bool``, *optional*):
             Pass True if the photo needs to be covered with a spoiler animation.
     """
@@ -61,8 +64,9 @@ class InputMediaPhoto(InputMedia):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         has_spoiler: bool | None = None,
     ):
-        super().__init__(media, caption, parse_mode, caption_entities)
+        super().__init__(media, caption, parse_mode, caption_entities, show_caption_above_media)
 
         self.has_spoiler = has_spoiler

--- a/hydrogram/types/input_media/input_media_video.py
+++ b/hydrogram/types/input_media/input_media_video.py
@@ -57,6 +57,9 @@ class InputMediaVideo(InputMedia):
         caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
             List of special entities that appear in the caption, which can be specified instead of *parse_mode*.
 
+        show_caption_above_media (``bool``, *optional*):
+            Wether the caption should be shown above the video.
+
         width (``int``, *optional*):
             Video width.
 
@@ -84,6 +87,7 @@ class InputMediaVideo(InputMedia):
         caption: str = "",
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         width: int = 0,
         height: int = 0,
         duration: int = 0,
@@ -91,7 +95,7 @@ class InputMediaVideo(InputMedia):
         has_spoiler: bool | None = None,
         no_sound: bool | None = None,
     ):
-        super().__init__(media, caption, parse_mode, caption_entities)
+        super().__init__(media, caption, parse_mode, caption_entities, show_caption_above_media)
 
         self.thumb = thumb
         self.width = width

--- a/hydrogram/types/messages_and_media/location.py
+++ b/hydrogram/types/messages_and_media/location.py
@@ -16,6 +16,7 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import annotations
 
 import hydrogram
 from hydrogram import raw
@@ -31,16 +32,32 @@ class Location(Object):
 
         latitude (``float``):
             Latitude as defined by sender.
+
+        horizontal_accuracy (``int``, *optional*):
+            The estimated horizontal accuracy of the location, in meters, as defined by sender.
     """
 
-    def __init__(self, *, client: "hydrogram.Client" = None, longitude: float, latitude: float):
+    def __init__(
+        self,
+        *,
+        client: hydrogram.Client = None,
+        longitude: float,
+        latitude: float,
+        horizontal_accuracy: int | None,
+    ):
         super().__init__(client)
 
         self.longitude = longitude
         self.latitude = latitude
+        self.horizontal_accuracy = horizontal_accuracy
 
     @staticmethod
-    def _parse(client, geo_point: "raw.types.GeoPoint") -> "Location":
+    def _parse(client, geo_point: raw.types.GeoPoint) -> Location:
         if isinstance(geo_point, raw.types.GeoPoint):
-            return Location(longitude=geo_point.long, latitude=geo_point.lat, client=client)
+            return Location(
+                longitude=geo_point.long,
+                latitude=geo_point.lat,
+                horizontal_accuracy=geo_point.accuracy_radius,
+                client=client,
+            )
         return None

--- a/hydrogram/types/messages_and_media/message.py
+++ b/hydrogram/types/messages_and_media/message.py
@@ -170,6 +170,9 @@ class Message(Object, Update):
             For messages with a caption, special entities like usernames, URLs, bot commands, etc. that appear
             in the caption.
 
+        show_caption_above_media (``bool``, *optional*):
+            Message's caption should be shown above the media.
+
         audio (:obj:`~hydrogram.types.Audio`, *optional*):
             Message is an audio file, information about the file.
 
@@ -378,6 +381,7 @@ class Message(Object, Update):
         text: Str = None,
         entities: list[types.MessageEntity] | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         audio: types.Audio = None,
         document: types.Document = None,
         photo: types.Photo = None,
@@ -462,6 +466,7 @@ class Message(Object, Update):
         self.text = text
         self.entities = entities
         self.caption_entities = caption_entities
+        self.show_caption_above_media = show_caption_above_media
         self.audio = audio
         self.document = document
         self.photo = photo
@@ -3380,6 +3385,7 @@ class Message(Object, Update):
         message_thread_id: int | None = None,
         parse_mode: enums.ParseMode | None = None,
         caption_entities: list[types.MessageEntity] | None = None,
+        show_caption_above_media: bool | None = None,
         disable_notification: bool | None = None,
         reply_to_message_id: int | None = None,
         schedule_date: datetime | None = None,
@@ -3425,6 +3431,9 @@ class Message(Object, Update):
 
             caption_entities (List of :obj:`~hydrogram.types.MessageEntity`):
                 List of special entities that appear in the new caption, which can be specified instead of *parse_mode*.
+
+            show_caption_above_media (``bool``, *optional*):
+                Pass True if the caption should be shown above the media.
 
             disable_notification (``bool``, *optional*):
                 Sends the message silently.
@@ -3574,6 +3583,7 @@ class Message(Object, Update):
                 caption=caption,
                 parse_mode=parse_mode,
                 caption_entities=caption_entities,
+                show_caption_above_media=show_caption_above_media,
                 message_thread_id=message_thread_id,
             )
         raise ValueError("Can't copy this message")


### PR DESCRIPTION
## Description

This PR is an effort to catch missing attributes from current objects. This PR currently does the following
 - Add support for `show_caption_above_media` (aka `invert_media` in MTProto) in methods and input objects where there's a caption.
 - Add support for defining the accuracy of the sent location with `horizontal_accuracy`.
 - Fix the `parse_mode` attribute type hint of `InputMedia`, which was still type hinted with a string (instead of an enum).
 