### PR TITLE
Fix correct client shutdown

### DIFF
--- a/hydrogram/client.py
+++ b/hydrogram/client.py
@@ -309,7 +309,7 @@ class Client(Methods):
 
         self.parser = Parser(self)
 
-        self.session = None
+        self.session: Session | None = None
 
         self.media_sessions = {}
         self.media_sessions_lock = asyncio.Lock()
@@ -318,8 +318,8 @@ class Client(Methods):
         self.save_file_semaphore = asyncio.Semaphore(self.max_concurrent_transmissions)
         self.get_file_semaphore = asyncio.Semaphore(self.max_concurrent_transmissions)
 
-        self.is_connected = None
-        self.is_initialized = None
+        self.is_connected: bool | None = None
+        self.is_initialized: bool | None = None
 
         self.takeout_id = None
 

--- a/hydrogram/methods/auth/disconnect.py
+++ b/hydrogram/methods/auth/disconnect.py
@@ -28,17 +28,11 @@ class Disconnect:
         self: "hydrogram.Client",
     ):
         """Disconnect the client from Telegram servers.
-
-        Raises:
-            ConnectionError: In case you try to disconnect an already disconnected client or in case you try to
-                disconnect a client that needs to be terminated first.
         """
-        if not self.is_connected:
-            raise ConnectionError("Client is already disconnected")
+        if self.session:
+            await self.session.stop()
 
-        if self.is_initialized:
-            raise ConnectionError("Can't disconnect an initialized client")
+        if self.storage:
+            await self.storage.close()
 
-        await self.session.stop()
-        await self.storage.close()
         self.is_connected = False

--- a/hydrogram/methods/auth/terminate.py
+++ b/hydrogram/methods/auth/terminate.py
@@ -16,7 +16,8 @@
 #
 #  You should have received a copy of the GNU Lesser General Public License
 #  along with Hydrogram.  If not, see <http://www.gnu.org/licenses/>.
-
+import asyncio
+import contextlib
 import logging
 
 import hydrogram
@@ -33,29 +34,28 @@ class Terminate:
 
         This method does the opposite of :meth:`~hydrogram.Client.initialize`.
         It will stop the dispatcher and shut down updates and download workers.
-
-        Raises:
-            ConnectionError: In case you try to terminate a client that is already terminated.
         """
-        if not self.is_initialized:
-            raise ConnectionError("Client is already terminated")
-
         if self.takeout_id:
-            await self.invoke(raw.functions.account.FinishTakeoutSession())
-            log.info("Takeout session %s finished", self.takeout_id)
+            with contextlib.suppress(Exception):
+                await self.invoke(raw.functions.account.FinishTakeoutSession())
+                log.info("Takeout session %s finished", self.takeout_id)
 
-        await self.storage.save()
-        await self.dispatcher.stop()
+        if self.storage:
+            await self.storage.save()
 
-        for media_session in self.media_sessions.values():
-            await media_session.stop()
+        if self.dispatcher:
+            await self.dispatcher.stop()
 
-        self.media_sessions.clear()
+        if self.media_sessions:
+            for media_session in self.media_sessions.values():
+                await media_session.stop()
+            self.media_sessions.clear()
 
         self.updates_watchdog_event.set()
 
         if self.updates_watchdog_task is not None:
-            await self.updates_watchdog_task
+            with contextlib.suppress(asyncio.TimeoutError, asyncio.CancelledError):
+                await asyncio.wait_for(self.updates_watchdog_task, timeout=1.0)
 
         self.updates_watchdog_event.clear()
 

--- a/hydrogram/session/session.py
+++ b/hydrogram/session/session.py
@@ -176,6 +176,14 @@ class Session:
 
         self.stored_msg_ids.clear()
 
+        if self.recv_task and not self.recv_task.done():
+            self.recv_task.cancel()
+
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError, RuntimeError):
+                await asyncio.wait_for(self.recv_task, timeout=1.0)
+
+            self.recv_task = None
+
         self.ping_task_event.set()
 
         if self.ping_task is not None:
@@ -185,14 +193,6 @@ class Session:
 
         if self.connection:
             await self.connection.close()
-
-        if self.recv_task and not self.recv_task.done():
-            self.recv_task.cancel()
-
-            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError, RuntimeError):
-                await asyncio.wait_for(self.recv_task, timeout=1.0)
-
-            self.recv_task = None
 
         if not self.is_media and callable(self.client.disconnect_handler):
             try:


### PR DESCRIPTION
## Description

This PR improves the client shutdown and termination logic to ensure reliable resource cleanup. 

Previously, the shutdown sequence relied on internal flags (`is_initialized`, `is_connected`) that might not update fast enough when managed via a fast-paced UI (e.g., Streamlit). This caused the client to remain active in the background or hang for 10 seconds due to `recv_task` not being cancelled correctly.

Removing explicit exceptions makes resource cleanup idempotent. In an asynchronous environment, a shutdown signal can arrive at any stage, even during partial initialization. By allowing methods to return normally rather than throwing errors, we ensure that the cleanup chain is not interrupted. This allows the library to always release resources (sockets and tasks) without leaving “zombies” running in the background.

**Key changes:**
- Made `terminate` and `disconnect` idempotent by checking for object existence instead of volatile flags.
- Ensured `recv_task` is explicitly cancelled and awaited before closing the connection.
- Fixed a race condition where errors during shutdown prevented full resource cleanup.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The changes were tested using a Streamlit-based management UI by rapidly toggling the bot's state.

- [x] Verified that rapid "Start -> Stop" sequences result in immediate socket closure without the 10-second MTProto timeout.
- [x] Confirmed that no `ConnectionError` or `AttributeError` is raised if `stop()` is called before the client is fully initialized.

### Test Configuration

- Operating System: macOS
- Python Version: 3.14

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes